### PR TITLE
Updated create_group and main functions within central_groups.py module. 

### DIFF
--- a/plugins/modules/central_groups.py
+++ b/plugins/modules/central_groups.py
@@ -125,7 +125,7 @@ EXAMPLES = """
         wired: false
         wireless: False
     architecture: AOS10
-    device_types: AccessPoints
+    device_type: AccessPoints
     ap_role: Standard
     gw_role: Standard
     switch_type: AOS_CX

--- a/plugins/modules/central_groups.py
+++ b/plugins/modules/central_groups.py
@@ -350,7 +350,7 @@ def main():
                     architecture=dict(type="str", choices=["Instant", "AOS10", "SD_WAN_Gateway"], required=False),
                     device_type=dict(type="list", choices=["Gateways", "AccessPoints", "Switches", "SD_WAN_Gateway"], required=True),
                     ap_role=dict(type="str", choices=["Standard", "Microbranch"], required=False),
-                    gw_role=dict(type="str", choices=["Branchgateway", "VPNConcentrator", "WLANGateway"], required=False),
+                    gw_role=dict(type="str", choices=["BranchGateway", "VPNConcentrator", "WLANGateway"], required=False),
                     switch_type=dict(type="list", choices=["AOS_S", "AOS_CX"], required=False),
                     monitor_mode=dict(type="list", choices=["AOS_S", "AOS_CX"], required=False),
                     new_central=dict(type="str", choices=["True", "False"], required=False),


### PR DESCRIPTION
https://developer.arubanetworks.com/central/reference/apigroupscreate_group_v3

I've updated the create_group module and the main code section within the central_groups.py part of the ansible collection. I've done this as I wanted to automate our process of creating new Central Tenancies for both sites and groups and moving to V3 of the API  allows the creation of groups with the selection of choices required for managing a modern central tenancy. 

The below variables are defined within the module and can be used in the playbooks to allow the setting of the required variables for Gateways, APs and Switches. I've even included some example yaml for recent playbooks that I've tested. 

device_type - must be Gateways, AccessPoints, Switches, SD_WAN_Gateway and is a required variable. Data must be passed as an array.
architecture - must be Instant, AOS10 or SD_WAN_Gateway.
ap_role - Standard or Microbranch.
gw_role - BranchGateway, VPNConcentrator or WLANGateway.
switch_type - AOS_S or AOS_CX both can be chosen if required. Data must be passed as an array.
monitoriong_mode - AOS_S or AOS_CX both can be chosen if required. Data must be passed as an array.
new_central - Flag to specify that group is compatible with New Central workflows.

  - name: Create Switch Group
    central_groups:
      action: create
      group_name: Access-Switches
      group_attributes:
        device_type: [Switches]
        switch_type: [AOS_CX]

  - name: Create AP Group
    central_groups:
      action: create
      group_name: ARO-Access-PointsAOS10
      group_attributes:
        architecture: AOS10
        device_type: [AccessPoints]
        ap_role: Standard

  - name: Create Controller Group 
    central_groups:
      action: create
      group_name: ARO-Controllers
      group_attributes:
        architecture: AOS10
        device_type: [Gateways]
        gw_role: WLANGateway

Signed-off-by: Sam Thomson sam.thomson.1991@gmail.com